### PR TITLE
feat(responses): now exposing the response methods

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) {{ year }}, {{ author }}
+Copyright (c) 2022, Omri Levy
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) {{ year }}, {{ author }}
+Copyright (c) 2022, Omri Levy
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,66 +3,66 @@
   "private": false,
   "sideEffects": false,
   "name": "@dry-express-responses/core",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",
   "files": [
-	"/dist"
+    "/dist"
   ],
   "license": "ISC",
   "repository": {
-	"type": "git",
-	"url": "https://github.com/Omri-Levy/dry-express-responses"
+    "type": "git",
+    "url": "https://github.com/Omri-Levy/dry-express-responses"
   },
   "description": "ExpressJS middleware to reduce boilerplate in response creation",
   "keywords": [
-	"express",
-	"response",
-	"middleware",
-	"http-status-codes",
-	"typescript",
-	"http",
-	"status"
+    "express",
+    "response",
+    "middleware",
+    "http-status-codes",
+    "typescript",
+    "http",
+    "status"
   ],
   "scripts": {
-	"release": "pnpm build && pnpm publish --access public",
-	"prepare": "ts-patch install -s",
-	"test": "echo \"Will add tests soon\"",
-	"clean": "rimraf dist",
-	"build:esm": "tsc --project tsconfig.json",
-	"build:cjs": "tsc --project tsconfig.cjs.json",
-	"build": "pnpm clean && pnpm build:esm && pnpm build:cjs",
-	"watch": "tsc --project tsconfig.json -w",
-	"lint": "eslint './src/**/*.{js,ts}' --fix",
-	"format": "prettier './src/**/*.{js,ts}' --write",
-	"typecheck": "tsc --noEmit --project tsconfig.json"
+    "release": "pnpm build && pnpm publish --access public",
+    "prepare": "ts-patch install -s",
+    "test": "echo \"Will add tests soon\"",
+    "clean": "rimraf dist",
+    "build:esm": "tsc --project tsconfig.json",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
+    "build": "pnpm clean && pnpm build:esm && pnpm build:cjs",
+    "watch": "tsc --project tsconfig.json -w",
+    "lint": "eslint './src/**/*.{js,ts}' --fix",
+    "format": "prettier './src/**/*.{js,ts}' --write",
+    "typecheck": "tsc --noEmit --project tsconfig.json"
   },
   "release": {
-	"branches": [
-	  "main"
-	]
+    "branches": [
+      "main"
+    ]
   },
   "devDependencies": {
-	"@dry-express-responses/types": "workspace:*",
-	"@types/express": "^4.17.13",
-	"@typescript-eslint/eslint-plugin": "^5.33.1",
-	"@typescript-eslint/parser": "^5.33.1",
-	"editorconfig": "^0.15.3",
-	"eslint": "^8.0.1",
-	"eslint-config-prettier": "^8.5.0",
-	"eslint-config-standard-with-typescript": "^22.0.0",
-	"eslint-plugin-import": "^2.25.2",
-	"eslint-plugin-n": "^15.0.0",
-	"eslint-plugin-promise": "^6.0.0",
-	"prettier": "^2.7.1",
-	"rimraf": "^3.0.2",
-	"semantic-release": "^19.0.3",
-	"ts-patch": "^2.0.2",
-	"tslib": "^2.4.0",
-	"typescript-transform-paths": "^3.3.1"
+    "@dry-express-responses/types": "workspace:*",
+    "@types/express": "^4.17.13",
+    "@typescript-eslint/eslint-plugin": "^5.33.1",
+    "@typescript-eslint/parser": "^5.33.1",
+    "editorconfig": "^0.15.3",
+    "eslint": "^8.0.1",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-config-standard-with-typescript": "^22.0.0",
+    "eslint-plugin-import": "^2.25.2",
+    "eslint-plugin-n": "^15.0.0",
+    "eslint-plugin-promise": "^6.0.0",
+    "prettier": "^2.7.1",
+    "rimraf": "^3.0.2",
+    "semantic-release": "^19.0.3",
+    "ts-patch": "^2.0.2",
+    "tslib": "^2.4.0",
+    "typescript-transform-paths": "^3.3.1"
   },
   "dependencies": {
-	"http-status-codes": "^2.2.0"
+    "http-status-codes": "^2.2.0"
   }
 }

--- a/packages/core/src/dry-express-responses.ts
+++ b/packages/core/src/dry-express-responses.ts
@@ -1,29 +1,45 @@
 import type { NextFunction, Request, Response } from 'express';
 import { StatusCodes } from 'http-status-codes';
-import { generateResponse, reasonPhraseToCamelCase } from './utils';
+import { reasonPhraseToCamelCase } from './utils';
+import {
+	badRequest,
+	created,
+	forbidden,
+	internalServerError,
+	notFound,
+	ok,
+	unauthorized,
+} from './responses';
 
+/**
+ * An ExpressJS middleware that overloads the response object by iterating over the most used status codes using http-status-codes, mapping them to their corresponding method. res.ok = ok(res) etc.
+ * @param req
+ * @param res
+ * @param next
+ */
 export const dryExpressResponses = (
 	req: Request,
 	res: Response,
 	next: NextFunction,
 ) => {
-	const withRes = generateResponse(res);
-
 	// Statuses to overload the response with.
 	[
-		StatusCodes.OK,
-		StatusCodes.CREATED,
-		StatusCodes.BAD_REQUEST,
-		StatusCodes.UNAUTHORIZED,
-		StatusCodes.FORBIDDEN,
-		StatusCodes.NOT_FOUND,
-		StatusCodes.INTERNAL_SERVER_ERROR,
-	].forEach((status) => {
+		{ status: StatusCodes.OK, cb: ok },
+		{ status: StatusCodes.CREATED, cb: created },
+		{ status: StatusCodes.BAD_REQUEST, cb: badRequest },
+		{ status: StatusCodes.UNAUTHORIZED, cb: unauthorized },
+		{ status: StatusCodes.FORBIDDEN, cb: forbidden },
+		{ status: StatusCodes.NOT_FOUND, cb: notFound },
+		{
+			status: StatusCodes.INTERNAL_SERVER_ERROR,
+			cb: internalServerError,
+		},
+	].forEach(({ status, cb }) => {
 		// Use the status code to get the reason phrase and convert
 		// it to camelCase. Bad Request -> badRequest
 		const method = reasonPhraseToCamelCase(status);
 
-		res[method] = withRes(status);
+		res[method] = cb(res);
 	});
 
 	return next();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,11 +7,27 @@ import type {
 } from '@dry-express-responses/types';
 import { dryExpressResponses } from './dry-express-responses';
 import { generateResponse, reasonPhraseToCamelCase } from './utils';
+import {
+	badRequest,
+	created,
+	forbidden,
+	internalServerError,
+	notFound,
+	ok,
+	unauthorized,
+} from './responses';
 
 export {
 	dryExpressResponses,
 	generateResponse,
 	reasonPhraseToCamelCase,
+	ok,
+	created,
+	badRequest,
+	unauthorized,
+	forbidden,
+	notFound,
+	internalServerError,
 };
 export type {
 	DryResponse,

--- a/packages/core/src/responses.ts
+++ b/packages/core/src/responses.ts
@@ -1,0 +1,24 @@
+import { generateResponse } from './utils';
+import { StatusCodes } from 'http-status-codes';
+import { Response } from 'express';
+
+export const ok = (res: Response) =>
+	generateResponse(res, StatusCodes.OK);
+
+export const created = (res: Response) =>
+	generateResponse(res, StatusCodes.CREATED);
+
+export const badRequest = (res: Response) =>
+	generateResponse(res, StatusCodes.BAD_REQUEST);
+
+export const unauthorized = (res: Response) =>
+	generateResponse(res, StatusCodes.UNAUTHORIZED);
+
+export const forbidden = (res: Response) =>
+	generateResponse(res, StatusCodes.FORBIDDEN);
+
+export const notFound = (res: Response) =>
+	generateResponse(res, StatusCodes.NOT_FOUND);
+
+export const internalServerError = (res: Response) =>
+	generateResponse(res, StatusCodes.INTERNAL_SERVER_ERROR);

--- a/packages/core/src/utils/generate-response.ts
+++ b/packages/core/src/utils/generate-response.ts
@@ -8,8 +8,7 @@ import type { ResponsePayload } from '@dry-express-responses/types';
  * @param status - The HTTP status code using http-status-codes.
  */
 export const generateResponse =
-	(res: Response) =>
-	(status: StatusCodes) =>
+	(res: Response, status: StatusCodes) =>
 	({ data, message, errors }: ResponsePayload) =>
 		res.status(status).send({
 			status: getReasonPhrase(status),

--- a/packages/core/src/utils/reason-phrase-to-camel-case.ts
+++ b/packages/core/src/utils/reason-phrase-to-camel-case.ts
@@ -2,6 +2,10 @@ import { getReasonPhrase, StatusCodes } from 'http-status-codes';
 import { startToCamelCase } from './start-to-camel-case';
 import { ResponseOverloads } from '@dry-express-responses/types';
 
+/**
+ * http-status-codes provides Start Case reason phrases, with this utility its possible to convert them to camelCase, to be used for object property keys, or to generate method names.
+ * @param status
+ */
 export const reasonPhraseToCamelCase = (status: StatusCodes) => {
 	const reasonPhrase = getReasonPhrase(status);
 	const camelReasonPhrase = startToCamelCase(reasonPhrase);

--- a/packages/core/src/utils/start-to-camel-case.ts
+++ b/packages/core/src/utils/start-to-camel-case.ts
@@ -1,3 +1,8 @@
+/**
+ * A utility that converts the first word of a string to lower case and removed the spaces.
+ * @example Bad Request -> badRequest
+ * @param str
+ */
 export const startToCamelCase = (str: string) =>
 	str
 		// Lowercase the first word.

--- a/packages/errors/LICENSE
+++ b/packages/errors/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) {{ year }}, {{ author }}
+Copyright (c) 2022, Omri Levy
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -3,7 +3,7 @@
   "sideEffects": false,
   "private": false,
   "name": "@dry-express-responses/errors",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/yup/LICENSE
+++ b/packages/yup/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) {{ year }}, {{ author }}
+Copyright (c) 2022, Omri Levy
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -2,7 +2,7 @@
 	"author": "Omri Levy",
 	"private": false,
 	"name": "@dry-express-responses/yup",
-	"version": "0.0.36",
+	"version": "0.0.37",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"types": "dist/cjs/index.d.ts",

--- a/packages/zod/LICENSE
+++ b/packages/zod/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) {{ year }}, {{ author }}
+Copyright (c) 2022, Omri Levy
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -2,7 +2,7 @@
   "author": "Omri Levy",
   "private": false,
   "name": "@dry-express-responses/zod",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.ts",


### PR DESCRIPTION
Allows using the response methods without the middleware or overloading the response object.

In cases where one feels uncomfortable with overloading the response object, these methods use
currying by passing response in the first invocation. This also means the first invocation can be
assigned to a variable so the response doesn't have to be passed in over and over again.